### PR TITLE
Validate ruby version >= 1.9.2 before attempting to run

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sly (0.0.11)
+    sly (0.0.12)
       curb (>= 0.8)
       gli (>= 2.5.0)
       json (>= 1.4)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To run the suite of tests, simply use the standard `rake` command.
   - v0.0.9  - Minor fix for item colour breakage
   - v0.0.10 - Update website details
   - v0.0.11 - Add license details to gemspec
+  - v0.0.12 - Display error to user when attempting to use a Ruby version < 1.9.2
 
 ## Licensing
 

--- a/bin/sly
+++ b/bin/sly
@@ -69,6 +69,7 @@ pre do |global,command,options,args|
   # chosen command
   # Use skips_pre before a command to skip this block
   # on that command only
+  Sly::VersionChecker.run
   Sly::Installer.validate_install!
   true
 end

--- a/lib/sly/version.rb
+++ b/lib/sly/version.rb
@@ -1,3 +1,11 @@
 module Sly
-  VERSION = '0.0.11'
+  VERSION = '0.0.12'
+
+  class VersionChecker
+    def self.run
+      minimum_version = Gem::Version.new('1.9.2')
+      current_version = Gem::Version.new(RUBY_VERSION)
+      raise 'Ruby versions less than 1.9.2 are not supported by Sly' if minimum_version > current_version
+    end
+  end
 end

--- a/sly.gemspec
+++ b/sly.gemspec
@@ -9,7 +9,8 @@ spec = Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.summary     = 'A small set of tools for working with Sprint.ly without leaving the command line.'
   s.description = 'A small set of tools for working with Sprint.ly without leaving the command line.'
-  s.license = "cc-zero"
+  s.license     = "cc-zero"
+  s.required_ruby_version = '>= 1.9.2'
 # Add your other files here if you make them
   s.files = Dir['bin/sly', 'lib/sly/version.rb', 'lib/sly.rb', 'lib/sly/*.rb']
   s.require_paths << 'lib'

--- a/spec/sly/version_spec.rb
+++ b/spec/sly/version_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Sly::VersionChecker do
+
+  describe "#run" do
+    before { OLD_RUBY_VERSION = RUBY_VERSION }
+    after { RUBY_VERSION = OLD_RUBY_VERSION }
+
+    context "when running a version < 1.9.2" do
+      it "raises an exception" do
+        RUBY_VERSION = "1.8.7"
+        expect { Sly::VersionChecker.run }.to raise_exception "Ruby versions less than 1.9.2 are not supported by Sly"
+      end
+    end
+
+    context "when running a version >= 1.9.2" do
+      it "does not raise an exception" do
+        RUBY_VERSION = "1.9.2"
+        expect { Sly::VersionChecker.run }.not_to raise_exception "Ruby versions less than 1.9.2 are not supported by Sly"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Set required ruby version of 1.9.2 
- Add version check for existing install/updates

Closes #18
