### PR TITLE
Use shorter feature branch names

### DIFF
--- a/lib/sly/item.rb
+++ b/lib/sly/item.rb
@@ -47,7 +47,13 @@ class Sly::Item
   end
 
   def slug
-    self.title.downcase.gsub(/(&|&amp;)/, ' and ').strip.gsub(/[^\w\s]/, '').gsub(/ to | the | +|_+/, '-')
+    if self.type == :feature
+      slug_string = self.title.downcase.match(/(as a.*i want.*) so that.*/)[1]
+    else
+      slug_string = self.title.downcase
+    end
+
+    slug_string.gsub(/(&|&amp;)/, 'and').gsub(/ to | the |\s+|_+|\//, '-').gsub(/[^\w-]/, '').squeeze('-')
   end
 
   def git_slug

--- a/spec/sly/branch_spec.rb
+++ b/spec/sly/branch_spec.rb
@@ -34,14 +34,14 @@ describe Sly::Branch do
       before do
         Sly::Item.stub(with_number: Sly::Item.new("number" => "500", "type"   => "story",
                                                   "status" => "in-progress", "score"  => "M",
-                                                  "title"  => "Magical wonderful story to narnia")
+                                                  "title"  => "As a user I want a title so that this makes sense")
                                                  )
       end
 
       context "branch does not exist" do
         it "creates the git branch" do
           Sly::Branch.for("500")
-          Sly::Branch.git(:branch).should =~ / feature\/magical-wonderful-story-narnia-500\n/
+          Sly::Branch.git(:branch).should =~ / feature\/as-a-user-i-want-a-title-500\n/
         end
       end
 

--- a/spec/sly/item_spec.rb
+++ b/spec/sly/item_spec.rb
@@ -100,6 +100,16 @@ describe Sly::Item do
       @item.slug.should =~ /-/
     end
 
+    it 'replaces slashes with hyphens' do
+      @item.title = "/"
+      @item.slug.should =~ /-/
+    end
+
+    it 'replaces successive hyphens' do
+      @item.title = "---"
+      @item.slug.should == "-"
+    end
+
     it "replaces & with ' and '" do
       @item.title = "&"
       @item.slug.should include "and"
@@ -114,6 +124,14 @@ describe Sly::Item do
 
     it "prepends the story type" do
       item.git_slug.should =~ /^task\/*/
+    end
+
+    context 'when a feature item' do
+      it 'uses the first two components of the description' do
+        item.type = :feature
+        item.title = 'As a user I want better branch names so that my pull-requests/descriptions are easier to understand.'
+        item.git_slug.should == 'feature/as-a-user-i-want-better-branch-names-204'
+      end
     end
   end
 end


### PR DESCRIPTION
- Only use first two components of feature branch names
- Make to_slug method produce cleaner slugs

Closes #19
