### PR TITLE
Show assigned to status

### DIFF
--- a/lib/sly/item.rb
+++ b/lib/sly/item.rb
@@ -5,7 +5,7 @@ class Sly::Item
   TYPE_COLOR = { task: :black, test: :blue, defect: :red, feature: :green }
   TYPES = { "task" => :task, "defect" => :defect, "story" => :feature, "test" => :test}
 
-  attr_accessor :number, :archived, :title, :score, :tags, :status, :type
+  attr_accessor :number, :archived, :title, :score, :tags, :status, :type, :assigned_to
 
   def self.with_number(number)
     begin
@@ -22,18 +22,19 @@ class Sly::Item
   end
 
   def initialize(item_attributes = {})
-    @number   = item_attributes["number"]
-    @archived = item_attributes["archived"]
-    @title    = item_attributes["title"]
-    @score    = item_attributes["score"]
-    @tags     = item_attributes["tags"]
-    @status   = item_attributes["status"]
-    @type     = TYPES[item_attributes["type"]].to_sym
+    @number       = item_attributes["number"]
+    @archived     = item_attributes["archived"]
+    @title        = item_attributes["title"]
+    @score        = item_attributes["score"]
+    @tags         = item_attributes["tags"]
+    @status       = item_attributes["status"]
+    @type         = TYPES[item_attributes["type"]].to_sym
+    @assigned_to  = assigned_to_s(item_attributes["assigned_to"])
   end
 
   def overview
-    quick_ref = "##{@number} - ".color(type_colour) + " #{@score} ".background(type_colour).color(:white)
-    self.prettify([quick_ref, @title.color(type_colour)].join("\n"), 44)+"\n"
+    quick_ref = "##{@number} - ".color(type_colour) + " #{@score} ".background(type_colour).color(:white) + " #{@assigned_to} ".color(type_colour)
+    self.prettify([quick_ref, @title.color(type_colour)].join("\n"), 180)+"\n"
   end
 
   alias_method :to_s, :overview
@@ -64,6 +65,11 @@ class Sly::Item
 
   def type_colour
     TYPE_COLOR[@type]
+  end
+
+  def assigned_to_s(assigned_to)
+    assigned_to ?
+      "Assigned to #{assigned_to["first_name"]} #{assigned_to["last_name"]}" : "Unassigned"
   end
 
 end

--- a/spec/sly/item_spec.rb
+++ b/spec/sly/item_spec.rb
@@ -42,6 +42,10 @@ describe Sly::Item do
     it "sets the type" do
       @item.type.should == :task
     end
+
+    it "sets the assigned to status" do
+      @item.assigned_to.should == "Assigned to Joe Stump"
+    end
   end
 
   describe :overview do


### PR DESCRIPTION
Also increased the max width value for `.prettify`. Mainly as it was cutting off the "Assigned to" to text and putting half on a new line. Could probably reduce the name to just `#{first_name} #{last_name[0]}` though. The limit for the width could be used when showing multiple columns with a single command, but at that point, things will probably be shortened anyway to get as much needed information on the screen in the smallest way possible.
